### PR TITLE
fix swagger gen conflict schemaIds - use CustomSchemaIds

### DIFF
--- a/save-points/2b-BackEnd-completed/ConferencePlanner/BackEnd/Startup.cs
+++ b/save-points/2b-BackEnd-completed/ConferencePlanner/BackEnd/Startup.cs
@@ -44,8 +44,10 @@ namespace BackEnd
 								.AddApiExplorer();
 
 						services.AddSwaggerGen(options =>
-								options.SwaggerDoc("v1", new Info { Title = "Conference Planner API", Version = "v1" })
-						);
+					      {
+						options.SwaggerDoc("v1", new Info { Title = "Conference Planner API", Version = "v1" });
+						options.CustomSchemaIds(c => c.FullName);
+					      });
 
 						services.AddMvc();
 				}


### PR DESCRIPTION
Swagger doc gen failed due to 
`
An unhandled exception has occurred while executing the request
System.InvalidOperationException: Conflicting schemaIds: Identical schemaIds detected for types
BackEnd.Data.Attendee and ConferenceDTO.Attendee. See config settings - "CustomSchemaIds" for a
workaround
`
Bellow is a link to relevant description:
https://stackoverflow.com/questions/46071513/swagger-error-conflicting-schemaids-duplicate-schemaids-detected-for-types-a-a