### PR TITLE
Fix for exception in Duration property.

### DIFF
--- a/docs/2. Build out BackEnd and Refactor.md
+++ b/docs/2. Build out BackEnd and Refactor.md
@@ -116,7 +116,7 @@ We've got several more models to add, and unfortunately it's a little mechanical
            public virtual DateTimeOffset? EndTime { get; set; }
    
            // Bonus points to those who can figure out why this is written this way
-           public TimeSpan Duration => EndTime?.Subtract(StartTime ?? EndTime ?? DateTime.MinValue) ?? TimeSpan.Zero;
+           public TimeSpan Duration => EndTime?.Subtract(StartTime ?? EndTime ?? DateTimeOffset.MinValue) ?? TimeSpan.Zero;
    
            public int? TrackId { get; set; }
        }


### PR DESCRIPTION
I tried out the code and there is a bug on line 119 in which if DateTime.MinValue is used it will throw a 
*ArgumentOutOfRangeException: The UTC time represented when the offset is applied must be between year 0 and 10,000.* 

Of course if the EndTime would be null to reach that point then it wouldn't even access the Subtract methods, but still :)