### PR TITLE
Remove including ConferenceResponse.cs from ConferenceDTO project file

### DIFF
--- a/src/ConferenceDTO/ConferenceDTO.csproj
+++ b/src/ConferenceDTO/ConferenceDTO.csproj
@@ -5,9 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="ConferenceResponse.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Explicitly including source file causes visual studio Intellisense error: duplicate class definition. 