### PR TITLE
Update session 6 - fix syntax highlighting and update Dockerfiles to 2.2

### DIFF
--- a/docs/6. Production Readiness and Deployment.md
+++ b/docs/6. Production Readiness and Deployment.md
@@ -273,7 +273,7 @@ Changes can be made to Razor pages and seen immediately without rebuilds, howeve
 
 ### Using VS Code or other editors
 
-Create and ddd the following Dockerfile for the BackEnd application.
+Create and add the following Dockerfile for the BackEnd application.
 
 ```Dockerfile
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS base
@@ -285,8 +285,9 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /src
 COPY ConferencePlanner.sln ./
 COPY BackEnd/BackEnd.csproj BackEnd/
+COPY FrontEnd/FrontEnd.csproj FrontEnd/
 COPY ConferenceDTO/ConferenceDTO.csproj ConferenceDTO/
-RUN dotnet restore -nowarn:msb3202,nu1503
+RUN dotnet restore
 COPY . .
 WORKDIR /src/BackEnd
 RUN dotnet build -c Release -o /app
@@ -301,7 +302,7 @@ ENTRYPOINT ["dotnet", "BackEnd.dll"]
 
 ```
 
-Create and ddd the following Dockerfile for the BackEnd application.
+Create and add the following Dockerfile for the BackEnd application.
 
 ```Dockerfile
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS base
@@ -312,9 +313,10 @@ EXPOSE 443
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /src
 COPY ConferencePlanner.sln ./
+COPY BackEnd/BackEnd.csproj BackEnd/
 COPY FrontEnd/FrontEnd.csproj FrontEnd/
 COPY ConferenceDTO/ConferenceDTO.csproj ConferenceDTO/
-RUN dotnet restore -nowarn:msb3202,nu1503
+RUN dotnet restore
 COPY . .
 WORKDIR /src/FrontEnd
 RUN dotnet build -c Release -o /app
@@ -342,7 +344,6 @@ services:
       dockerfile: BackEnd/Dockerfile
     ports:
       - "56009:80"
-      - "56001:443"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     depends_on:
@@ -354,8 +355,7 @@ services:
       context: .
       dockerfile: FrontEnd/Dockerfile
     ports:
-      - "5001:80"
-      - "5003:443"
+      - "5002:80"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
     links:
@@ -394,6 +394,7 @@ Remove or comment out the `.UseUrls(http://localhost:56009)` in BackEnd\Program.
 - Build the Docker images `docker-compose build`
 - Run `docker-compose up -d` to start the application
 - Run `docker-compose down` to stop the application
+- Open the application at <http://localhost:5002>
 
 ## Bonus
 

--- a/docs/6. Production Readiness and Deployment.md
+++ b/docs/6. Production Readiness and Deployment.md
@@ -108,13 +108,13 @@ A new project is added to the solution **docker-compose.dcproj** containing the 
 
 A **Dockerfile** is also added to the **BackEnd** project.
 
-```docker
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+```Dockerfile
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /src
 COPY ConferencePlanner.sln ./
 COPY BackEnd/BackEnd.csproj BackEnd/
@@ -135,13 +135,13 @@ ENTRYPOINT ["dotnet", "BackEnd.dll"]
 
 Repeat the same step for the **FrontEnd** project. The Dockerfile is added to the project for it.
 
-```docker
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+```Dockerfile
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /src
 COPY ConferencePlanner.sln ./
 COPY FrontEnd/FrontEnd.csproj FrontEnd/
@@ -162,7 +162,7 @@ ENTRYPOINT ["dotnet", "FrontEnd.dll"]
 
 The **docker-compose.yml** file is updated to reflect that there are two projects to build images.
 
-```docker
+```yaml
 version: '3'
 
 services:
@@ -193,7 +193,7 @@ Using Docker, adding a container for SQL Server and linking the containers in th
 
 Open the docker-compose.yml file and add the following entry. *Note the $ is doubled for escaping*
 
-```docker
+```yaml
   db:
     image: "microsoft/mssql-server-linux"
     environment:
@@ -203,7 +203,7 @@ Open the docker-compose.yml file and add the following entry. *Note the $ is dou
 
 Since the **BackEnd** application must have connectivity and cannot start until the database container is ready. Add the **depends_on** entry to the **backend** definition in the compose file.
 
-```docker
+```yaml
   backend:
     image: backend
     build:
@@ -225,7 +225,7 @@ Finally, change the connection string for the database in the BackEnd\appsetting
 
 In the **docker-compose.yml** file, add the **links** section to the **frontend** definition. This sets up the host name in the Docker networking allowing for the web application to call the API by name. `http://backend`
 
-```docker
+```yaml
   frontend:
     image: frontend
     build:
@@ -246,7 +246,7 @@ Remove or comment out the `.UseUrls(http://localhost:56009)` in BackEnd\Program.
 
 Finally open the **docker-compose.override.yml** file. Change the ports for the **backend** entry to `56009:80` and for the **frontend**, make it `5001:80`
 
-```docker
+```yaml
 version: '3'
 
 services:
@@ -275,13 +275,13 @@ Changes can be made to Razor pages and seen immediately without rebuilds, howeve
 
 Create and ddd the following Dockerfile for the BackEnd application.
 
-```docker
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+```Dockerfile
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /src
 COPY ConferencePlanner.sln ./
 COPY BackEnd/BackEnd.csproj BackEnd/
@@ -303,13 +303,13 @@ ENTRYPOINT ["dotnet", "BackEnd.dll"]
 
 Create and ddd the following Dockerfile for the BackEnd application.
 
-```docker
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
+```Dockerfile
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /src
 COPY ConferencePlanner.sln ./
 COPY FrontEnd/FrontEnd.csproj FrontEnd/
@@ -331,7 +331,7 @@ ENTRYPOINT ["dotnet", "FrontEnd.dll"]
 
 At the root of the ConferencePlanner solution, add the following **docker-compose.yml** file.
 
-```docker
+```yaml
 version: '3'
 
 services:


### PR DESCRIPTION
* Replace docker hub with MCR (see https://hub.docker.com/_/microsoft-dotnet-core)
* Update to 2.2 images
* Use correct syntax highlighting
* Remove HTTPS internal ports (there is no cert inside a Docker container)

@davidfowl 