### PR TITLE
Replace backslashes in paths used for dotnet commands

### DIFF
--- a/docs/1. Create BackEnd API project.md
+++ b/docs/1. Create BackEnd API project.md
@@ -10,7 +10,7 @@
    > ***Note:* If not using Visual Studio, create the project using `dotnet new webapi` at the cmd line, details as follows:**
    > 1. Create folder ConferencePlanner and call `dotnet new sln` at the cmd line to create a solution
    > 2. Create sub-folder BackEnd and create a project using `dotnet new webapi` at the cmd line inside the folder BackEnd
-   > 3. Add the project to the solution using `dotnet sln add BackEnd\BackEnd.csproj`
+   > 3. Add the project to the solution using `dotnet sln add BackEnd/BackEnd.csproj`
 1. Add a new `Models` folder to the root of the application.
 1. Add a new `Speaker` class using the following code:
     ```csharp

--- a/docs/2. Build out BackEnd and Refactor.md
+++ b/docs/2. Build out BackEnd and Refactor.md
@@ -25,7 +25,7 @@ In this session, we'll add the rest of our models and controllers that expose th
    ```
 1. Add the ConferenceDTO project to the solution:
    ```
-   dotnet sln add ConferenceDTO\ConferenceDTO.csproj
+   dotnet sln add ConferenceDTO/ConferenceDTO.csproj
    ```
 
 ## Refactoring the Speaker model into the ConferenceDTO project


### PR DESCRIPTION
Backslashes for paths don't work on Mac systems. This PR replaces them with forward slashes which work for both Mac and Windows (and presumably any *nix systems but I didn't test all those).